### PR TITLE
WIP: Implement sandboxes with nix-style package caching

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,5 +42,6 @@ tests:
 
     dependencies:
       - hspec
+      - hspec-expectations
       - mockery
       - silently

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -1,0 +1,15 @@
+module Util where
+
+import Data.List
+
+type PackageName = String
+
+parseInstallPlan :: String -> [PackageName]
+parseInstallPlan = concatMap (take 1 . words) . drop 2 . lines
+
+lookupPackage :: String -> [FilePath] -> Either String (Maybe FilePath)
+lookupPackage targetPackage packageFiles =
+  case filter ((targetPackage ++ "-") `isPrefixOf`) packageFiles of
+    [packageFile] -> return $ Just packageFile
+    [] -> return Nothing
+    multiple -> Left ("Package found multiple times: " ++ intercalate ", " multiple)

--- a/stack-sandbox.cabal
+++ b/stack-sandbox.cabal
@@ -83,6 +83,7 @@ test-suite spec
     , parsec
 
     , hspec
+    , hspec-expectations
     , mockery
     , silently
   ghc-options: -Wall -fno-warn-name-shadowing -threaded -O0

--- a/test/UtilSpec.hs
+++ b/test/UtilSpec.hs
@@ -1,0 +1,39 @@
+module UtilSpec where
+
+import           Test.Hspec
+import           Data.Either.Compat
+
+import           Util
+
+spec :: Spec
+spec = do
+  describe "parseInstallPlan" $ do
+    it "parses output from `cabal install --dry-run`" $ do
+      output <- readFile "test/resources/cabal-1.22.4.0-dry-run.txt"
+      parseInstallPlan output `shouldBe`
+        [ "base-compat-0.8.2"
+        , "base-orphans-0.3.2"
+        , "tagged-0.7.3"
+        , "generics-sop-0.1.1.2"
+        , "getopt-generics-0.6.3"
+        ]
+
+  describe "lookupPackage" $ do
+    let tagged = "tagged-0.7-ad0cd5417885ac66ae852f4c39d51376.conf"
+        tagged073 = "tagged-0.7.3-8d0cd5417885ac66ae852f4c39d51376.conf"
+        packageName = "tagged-0.7"
+
+    it "returns a package file for a given package" $ do
+      lookupPackage packageName [tagged] `shouldBe` Right (Just tagged)
+
+    context "when a package is the prefix of another package" $ do
+      it "can disambiguate them" $ do
+        lookupPackage packageName [tagged073, tagged] `shouldBe` Right (Just tagged)
+
+    context "when there is no package file for the given package" $ do
+      it "returns nothing" $ do
+        lookupPackage packageName [tagged073] `shouldBe` Right Nothing
+
+    context "when there are multiple package configs for the package" $ do
+      it "returns an error" $ do
+        lookupPackage packageName [tagged, tagged] `shouldSatisfy` isLeft

--- a/test/resources/cabal-1.22.4.0-dry-run.txt
+++ b/test/resources/cabal-1.22.4.0-dry-run.txt
@@ -1,0 +1,7 @@
+Resolving dependencies...
+In order, the following would be installed (use -v for more details):
+base-compat-0.8.2
+base-orphans-0.3.2
+tagged-0.7.3 (latest: 0.8.0.1)
+generics-sop-0.1.1.2
+getopt-generics-0.6.3


### PR DESCRIPTION
RFC

Working now:

 - Use 1 parent Cabal sandbox as the cache
 - Only register the packages used
 - Misc bug fixes